### PR TITLE
--ignore does not work with a single argument

### DIFF
--- a/bin/LOTS
+++ b/bin/LOTS
@@ -52,6 +52,7 @@ var argv = require('rc')(pkg.name, {
 });
 
 if (!argv.all) {
+  argv.ignore = typeof argv.ignore === 'string' ? [argv.ignore]: argv.ignore;
   argv.ignore = argv.ignore.concat(defaultIgnores);
 }
 


### PR DESCRIPTION
like:

--i 'src' results in a string - should be an array with a string